### PR TITLE
Fixed some warnings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,8 @@
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
         <repository>
-            <id>funnyboy_roks-snapshots</id>
-            <name>Funny's Maven Repository</name>
-            <url>https://maven.funnyboyroks.com/snapshots</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
         <repository>
             <id>enginehub-maven</id>
@@ -97,9 +96,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.funnyboyroks</groupId>
+            <groupId>com.github.funnyboy-roks</groupId>
             <artifactId>DrawLib</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>worldedit-selection-viewer</name>
 
     <properties>
-        <java.version>16</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,15 @@
                             <shadedPattern>com.funnyboyroks.worldeditselectionviewer</shadedPattern>
                         </relocation>
                     </relocations>
+                    <filters>
+                        <filter>
+                            <artifact>*.*</artifact>
+                            <excludes>
+                            <exclude>module-info.class</exclude>
+                            <exclude>META-INF/MANIFEST.MF</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/com/funnyboyroks/worldeditselectionviewer/Util.java
+++ b/src/main/java/com/funnyboyroks/worldeditselectionviewer/Util.java
@@ -16,9 +16,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.URI;
 import java.net.URL;
-import java.util.AbstractMap;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -105,9 +104,9 @@ public class Util {
     public static Location asLocation(BlockVector3 vec, World world) {
         return new Location(
             world,
-            vec.getBlockX(),
-            vec.getBlockY(),
-            vec.getBlockZ()
+            vec.x(),
+            vec.y(),
+            vec.z()
         );
     }
 
@@ -123,12 +122,12 @@ public class Util {
         return CompletableFuture.supplyAsync(() -> {
 
             try {
-                URL url = new URL("https://api.modrinth.com/v2/project/K9JIhdio");
+                URL url = URI.create("https://api.modrinth.com/v2/project/K9JIhdio").toURL();
                 InputStreamReader reader = new InputStreamReader(url.openStream());
                 JsonArray versions = JsonParser.parseReader(reader).getAsJsonObject().getAsJsonArray("versions");
                 String version = versions.get(versions.size() - 1).getAsString();
 
-                url = new URL("https://api.modrinth.com/v2/version/" + version);
+                url = URI.create("https://api.modrinth.com/v2/version/" + version).toURL();
                 reader = new InputStreamReader(url.openStream());
                 int latestVersion = Integer.parseInt(
                     JsonParser.parseReader(reader)


### PR DESCRIPTION
This is tiny commit.
There is no change in behavior.
This is a change only to the development environment.

BEFORE:
```console
$ mvn package
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------< com.funnyboyroks:worldedit-selection-viewer >-------------
[INFO] Building worldedit-selection-viewer 1.5
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ worldedit-selection-viewer ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.13.0:compile (default-compile) @ worldedit-selection-viewer ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 3 source files with javac [debug target 16] to target/classes
[WARNING] system modules path not set in conjunction with -source 16
[WARNING] /mnt/e/P/private/worldedit-selection-viewer/src/main/java/com/funnyboyroks/worldeditselectionviewer/Util.java:[108,16] getBlockX() in com.sk89q.worldedit.math.BlockVector3 has been deprecated and marked for removal
[WARNING] /mnt/e/P/private/worldedit-selection-viewer/src/main/java/com/funnyboyroks/worldeditselectionviewer/Util.java:[109,16] getBlockY() in com.sk89q.worldedit.math.BlockVector3 has been deprecated and marked for removal
[WARNING] /mnt/e/P/private/worldedit-selection-viewer/src/main/java/com/funnyboyroks/worldeditselectionviewer/Util.java:[110,16] getBlockZ() in com.sk89q.worldedit.math.BlockVector3 has been deprecated and marked for removal
[INFO] /mnt/e/P/private/worldedit-selection-viewer/src/main/java/com/funnyboyroks/worldeditselectionviewer/Util.java: /mnt/e/P/private/worldedit-selection-viewer/src/main/java/com/funnyboyroks/worldeditselectionviewer/Util.java uses or overrides a deprecated API.
[INFO] /mnt/e/P/private/worldedit-selection-viewer/src/main/java/com/funnyboyroks/worldeditselectionviewer/Util.java: Recompile with -Xlint:deprecation for details.
[INFO]
[INFO] --- resources:3.3.1:testResources (default-testResources) @ worldedit-selection-viewer ---
[INFO] skip non existing resourceDirectory /mnt/e/P/private/worldedit-selection-viewer/src/test/resources
[INFO]
[INFO] --- compiler:3.13.0:testCompile (default-testCompile) @ worldedit-selection-viewer ---
[INFO] No sources to compile
[INFO]
[INFO] --- surefire:3.2.5:test (default-test) @ worldedit-selection-viewer ---
[INFO] No tests to run.
[INFO] 
[INFO] --- jar:3.4.1:jar (default-jar) @ worldedit-selection-viewer ---
[INFO] Building jar: /mnt/e/P/private/worldedit-selection-viewer/target/worldedit-selection-viewer-1.5.jar
[INFO] 
[INFO] --- shade:3.6.0:shade (default) @ worldedit-selection-viewer ---
[INFO] Including com.github.funnyboy-roks:DrawLib:jar:1.1.0-SNAPSHOT in the shaded jar.
[INFO] Including org.bstats:bstats-bukkit:jar:3.0.2 in the shaded jar.
[INFO] Including org.bstats:bstats-base:jar:3.0.2 in the shaded jar.
[WARNING] DrawLib-1.1.0-SNAPSHOT.jar, bstats-base-3.0.2.jar, bstats-bukkit-3.0.2.jar, worldedit-selection-viewer-1.5.jar define 1 overlapping resource:
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] maven-shade-plugin has detected that some files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the file is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See https://maven.apache.org/plugins/maven-shade-plugin/
[INFO] Replacing original artifact with shaded artifact.
[INFO] Replacing /mnt/e/P/private/worldedit-selection-viewer/target/worldedit-selection-viewer-1.5.jar with /mnt/e/P/private/worldedit-selection-viewer/target/worldedit-selection-viewer-1.5-shaded.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.628 s
[INFO] Finished at: 2025-01-23T17:08:34+09:00
[INFO] ------------------------------------------------------------------------
```

AFTER:
```console
$ mvn package
[INFO] Scanning for projects...
[INFO] 
[INFO] ------------< com.funnyboyroks:worldedit-selection-viewer >-------------
[INFO] Building worldedit-selection-viewer 1.5
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ worldedit-selection-viewer ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] 
[INFO] --- compiler:3.13.0:compile (default-compile) @ worldedit-selection-viewer ---
[INFO] Recompiling the module because of added or removed source files.
[INFO] Compiling 3 source files with javac [debug target 16] to target/classes
[WARNING] system modules path not set in conjunction with -source 16
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ worldedit-selection-viewer ---
[INFO] skip non existing resourceDirectory /mnt/e/P/private/worldedit-selection-viewer/src/test/resources
[INFO]
[INFO] --- compiler:3.13.0:testCompile (default-testCompile) @ worldedit-selection-viewer ---
[INFO] No sources to compile
[INFO]
[INFO] --- surefire:3.2.5:test (default-test) @ worldedit-selection-viewer ---
[INFO] No tests to run.
[INFO] 
[INFO] --- jar:3.4.1:jar (default-jar) @ worldedit-selection-viewer ---
[INFO] Building jar: /mnt/e/P/private/worldedit-selection-viewer/target/worldedit-selection-viewer-1.5.jar
[INFO] 
[INFO] --- shade:3.6.0:shade (default) @ worldedit-selection-viewer ---
[INFO] Including com.github.funnyboy-roks:DrawLib:jar:1.1.0-SNAPSHOT in the shaded jar.
[INFO] Including org.bstats:bstats-bukkit:jar:3.0.2 in the shaded jar.
[INFO] Including org.bstats:bstats-base:jar:3.0.2 in the shaded jar.
[INFO] Replacing original artifact with shaded artifact.
[INFO] Replacing /mnt/e/P/private/worldedit-selection-viewer/target/worldedit-selection-viewer-1.5.jar with /mnt/e/P/private/worldedit-selection-viewer/target/worldedit-selection-viewer-1.5-shaded.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.856 s
[INFO] Finished at: 2025-01-23T19:00:42+09:00
[INFO] ------------------------------------------------------------------------
```

My JDK is 21.
`[WARNING] system modules path not set in conjunction with -source 16`
If the JDK versions in your development environment match, this warning will not appear.

JDK|Minecraft Version|LTS
--|--|--
JDK  8 | 1.7.10 ~ 1.16.5|
JDK 11 | 1.7.10 ~ 1.16.5|✔
JDK 16 | 1.17 ~ 1.17.1|
JDK 17 | 1.17 ~ 1.20.4|✔
JDK 21 | 1.20.5 ~|✔
